### PR TITLE
Ensuring PSD func has needed functions

### DIFF
--- a/index.webpack.js
+++ b/index.webpack.js
@@ -1,4 +1,13 @@
-require('./shims/png.coffee');
-require('./shims/init.coffee');
+png = require('./shims/png.coffee');
+init = require('./shims/init.coffee');
+psd = require('./lib/psd.coffee');
 
-module.exports = require('./lib/psd.coffee');
+extended = init.extended(psd);
+
+psd.prototype.toBase64 = png.toBase64;
+
+psd.fromDroppedFile = init.fromDroppedFile;
+psd.fromEvent = init.fromEvent;
+psd.fromURL = init.fromURL;
+
+module.exports = psd;


### PR DESCRIPTION
The webpack'd version of psd.js that we've hacked together wasn't
playing nice with ProjectView in Marvelapp, because the fromDroppedFile
was absent. I had to attach it, as well as attach the toBase64 function
to the PSD function (the main exported object) so that it could be used
in the appropriate place when the time comes (see ProjectView in an
upcoming PR on `marvelapp_pie`).

I realise this is somewhat hacky, but I struggled for a while to try to
mimic what the psd.js `Cakefile` does when it compiles the library for
the web using Browserify and failed. This works :)
